### PR TITLE
Fixed: 结束时间必须大于等于开始时间

### DIFF
--- a/app/Admin/Controllers/CouponCodesController.php
+++ b/app/Admin/Controllers/CouponCodesController.php
@@ -113,7 +113,7 @@ class CouponCodesController extends Controller
             $form->text('total', '总量')->rules('required|numeric|min:0');
             $form->text('min_amount', '最低金额')->rules('required|numeric|min:0');
             $form->datetime('not_before', '开始时间');
-            $form->datetime('not_after', '结束时间');
+            $form->datetime('not_after', '结束时间')->rules('after_or_equal:not_before', ['after_or_equal' => '结束时间必须大于或等于开始时间']);;
             $form->radio('enabled', '启用')->options(['1' => '是', '0' => '否']);
 
             $form->saving(function (Form $form) {


### PR DESCRIPTION
修复前![image](https://user-images.githubusercontent.com/25813184/50056056-e1b2fc00-0191-11e9-850d-1937262110b5.png)
会出现开始时间大于结束时间的情况，
修复后
![image](https://user-images.githubusercontent.com/25813184/50056064-fd1e0700-0191-11e9-84fd-35516fa24cff.png)

